### PR TITLE
Move portfolio to its own page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import PortfolioPage from "./pages/Portfolio";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/portfolio" element={<PortfolioPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import { Instagram, MessageSquare, Mail } from "lucide-react";
 const Footer = () => {
   const quickLinks = [
     { name: "Home", href: "#home" },
-    { name: "Portfolio", href: "#portfolio" },
+    { name: "Portfolio", href: "/portfolio" },
     { name: "Creative Dimensions", href: "#dimensions" },
     { name: "Contact", href: "#contact" },
   ];

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,7 +7,7 @@ const Header = () => {
 
   const navigation = [
     { name: "Home", href: "#home" },
-    { name: "Portfolio", href: "#portfolio" },
+    { name: "Portfolio", href: "/portfolio" },
     { name: "Creative Dimensions", href: "#dimensions" },
     { name: "Contact", href: "#contact" },
   ];

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,9 @@
 import { Button } from "@/components/ui/button";
 import heroImage from "@/assets/hero-cubes.jpg";
+import { useNavigate } from "react-router-dom";
 
 const Hero = () => {
+  const navigate = useNavigate();
   return (
     <section id="home" className="min-h-screen flex items-center justify-center relative overflow-hidden">
       {/* Background Image */}
@@ -40,11 +42,11 @@ const Hero = () => {
 
           {/* Call-to-Action Buttons */}
           <div className="flex flex-col sm:flex-row gap-6 justify-center items-center">
-            <Button 
-              variant="hero" 
-              size="lg" 
+            <Button
+              variant="hero"
+              size="lg"
               className="px-8 py-4 text-lg font-semibold min-w-[200px]"
-              onClick={() => document.getElementById('portfolio')?.scrollIntoView({ behavior: 'smooth' })}
+              onClick={() => navigate('/portfolio')}
             >
               View Portfolio
             </Button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,6 @@
 import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import CreativeDimensions from "@/components/CreativeDimensions";
-import Portfolio from "@/components/Portfolio";
 import Contact from "@/components/Contact";
 import Footer from "@/components/Footer";
 
@@ -12,7 +11,6 @@ const Index = () => {
       <main>
         <Hero />
         <CreativeDimensions />
-        <Portfolio />
         <Contact />
       </main>
       <Footer />

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,0 +1,17 @@
+import Header from "@/components/Header";
+import Portfolio from "@/components/Portfolio";
+import Footer from "@/components/Footer";
+
+const PortfolioPage = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main>
+        <Portfolio />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default PortfolioPage;


### PR DESCRIPTION
## Summary
- route `/portfolio` renders a dedicated portfolio page
- drop portfolio section from the homepage
- update navigation links and hero button to point to `/portfolio`

## Testing
- `npm run lint` *(fails: 3 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68729836ad5c832ea132a17bf8204860