### PR TITLE
Update hero text and fix nav links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,10 +2,10 @@ import { Instagram, MessageSquare, Mail } from "lucide-react";
 
 const Footer = () => {
   const quickLinks = [
-    { name: "Home", href: "#home" },
+    { name: "Home", href: "/#home" },
     { name: "Portfolio", href: "/portfolio" },
-    { name: "Creative Dimensions", href: "#dimensions" },
-    { name: "Contact", href: "#contact" },
+    { name: "Creative Dimensions", href: "/#dimensions" },
+    { name: "Contact", href: "/#contact" },
   ];
 
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,10 +6,10 @@ const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const navigation = [
-    { name: "Home", href: "#home" },
+    { name: "Home", href: "/#home" },
     { name: "Portfolio", href: "/portfolio" },
-    { name: "Creative Dimensions", href: "#dimensions" },
-    { name: "Contact", href: "#contact" },
+    { name: "Creative Dimensions", href: "/#dimensions" },
+    { name: "Contact", href: "/#contact" },
   ];
 
   return (
@@ -17,13 +17,13 @@ const Header = () => {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
-          <div className="flex items-center">
+          <a href="/#home" className="flex items-center">
             <div className="text-2xl font-bold font-montserrat text-foreground">
               <span className="text-neon-pink">3D</span>
               <span className="text-neon-cyan">imension</span>
               <span className="text-blue-violet">Labs</span>
             </div>
-          </div>
+          </a>
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-8">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -26,13 +26,13 @@ const Hero = () => {
         <div className="max-w-4xl mx-auto animate-fade-in-up">
           {/* Main Headline */}
           <h1 className="text-5xl md:text-7xl font-bold font-montserrat mb-6 leading-tight">
-            We turn <span className="text-neon-pink">ideas</span> into{" "}
-            <span className="text-neon-cyan">reality</span>
+            Transformamos <span className="text-neon-pink">ideias</span> em{" "}
+            <span className="text-neon-cyan">realidade</span>
           </h1>
-          
+
           {/* Subheading */}
           <p className="text-xl md:text-2xl font-medium font-montserrat mb-4 text-muted-foreground">
-            with precision, quality, and innovation
+            uma dimensão sem limites para criatividade
           </p>
           
           {/* Tagline */}


### PR DESCRIPTION
## Summary
- show hero headline and subheading in Portuguese
- link header logo and nav items to homepage anchors for cross-page nav
- update footer quick links

## Testing
- `npm run lint` *(fails: no-empty-object-type, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6873c4ed5290832eae1a92d6ba1cd147