### PR TITLE
Translate website content to Portuguese

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>3DimensionLabs - The dimension with no limits to creativity</title>
-    <meta name="description" content="Transform ideas into reality through precision 3D printing. On-demand printing, quality under control, innovation without boundaries." />
+    <title>3DimensionLabs - A dimensão sem limites para a criatividade</title>
+    <meta name="description" content="Transforme ideias em realidade com impressão 3D de precisão. Impressão sob demanda, qualidade sob controle e inovação sem fronteiras." />
     <meta name="author" content="3DimensionLabs" />
 
-    <meta property="og:title" content="3DimensionLabs - The dimension with no limits to creativity" />
-    <meta property="og:description" content="Transform ideas into reality through precision 3D printing. On-demand printing, quality under control." />
+    <meta property="og:title" content="3DimensionLabs - A dimensão sem limites para a criatividade" />
+    <meta property="og:description" content="Transforme ideias em realidade com impressão 3D de precisão. Impressão sob demanda, qualidade sob controle." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -19,8 +19,8 @@ const Contact = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     toast({
-      title: "Project Started!",
-      description: "We'll respond within 24 hours with next steps.",
+      title: "Projeto iniciado!",
+      description: "Responderemos em até 24 horas com os próximos passos.",
     });
     // Reset form
     setFormData({ name: "", email: "", message: "", file: null });
@@ -36,13 +36,13 @@ const Contact = () => {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-bold font-montserrat mb-6">
-              Got an <span className="text-neon-pink">idea</span>?{" "}
-              <span className="text-neon-cyan">Let's make it real</span> in 3D
-            </h2>
-            <p className="text-xl text-muted-foreground font-montserrat max-w-3xl mx-auto">
-              Tell us about your idea, and we'll help print it into existence
-            </p>
+          <h2 className="text-4xl md:text-5xl font-bold font-montserrat mb-6">
+            Teve uma <span className="text-neon-pink">ideia</span>?{' '}
+            <span className="text-neon-cyan">Vamos torná-la real</span> em 3D
+          </h2>
+          <p className="text-xl text-muted-foreground font-montserrat max-w-3xl mx-auto">
+            Conte-nos sobre sua ideia e ajudaremos a imprimi-la
+          </p>
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -50,10 +50,10 @@ const Contact = () => {
             <Card className="lg:col-span-2 border-2 hover:border-neon-pink transition-colors duration-300">
               <CardHeader>
                 <CardTitle className="text-2xl font-bold font-montserrat">
-                  Start Your Project
+                  Inicie seu projeto
                 </CardTitle>
                 <CardDescription className="font-montserrat">
-                  Share your vision and we'll bring it to life with precision 3D printing
+                  Compartilhe sua visão e a transformaremos em realidade com impressão 3D de precisão
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -61,7 +61,7 @@ const Contact = () => {
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                       <Label htmlFor="name" className="font-montserrat font-medium">
-                        Name *
+                        Nome *
                       </Label>
                       <Input
                         id="name"
@@ -70,7 +70,7 @@ const Contact = () => {
                         value={formData.name}
                         onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                         className="mt-1 border-2 focus:border-neon-pink font-montserrat"
-                        placeholder="Your name"
+                        placeholder="Seu nome"
                       />
                     </div>
                     <div>
@@ -91,7 +91,7 @@ const Contact = () => {
 
                   <div>
                     <Label htmlFor="message" className="font-montserrat font-medium">
-                      Project Description *
+                      Descrição do Projeto *
                     </Label>
                     <Textarea
                       id="message"
@@ -99,13 +99,13 @@ const Contact = () => {
                       value={formData.message}
                       onChange={(e) => setFormData({ ...formData, message: e.target.value })}
                       className="mt-1 border-2 focus:border-neon-pink font-montserrat min-h-[120px]"
-                      placeholder="Describe your idea, dimensions, materials, and any specific requirements..."
+                      placeholder="Descreva sua ideia, dimensões, materiais e quaisquer requisitos específicos..."
                     />
                   </div>
 
                   <div>
                     <Label htmlFor="file" className="font-montserrat font-medium">
-                      Attach Files (Optional)
+                      Anexar Arquivos (Opcional)
                     </Label>
                     <div className="mt-1 flex items-center space-x-4">
                       <Input
@@ -118,7 +118,7 @@ const Contact = () => {
                       <Upload className="text-muted-foreground" size={20} />
                     </div>
                     <p className="text-sm text-muted-foreground mt-1 font-montserrat">
-                      Upload sketches, 3D models, or reference images
+                      Envie esboços, modelos 3D ou imagens de referência
                     </p>
                   </div>
 
@@ -128,12 +128,12 @@ const Contact = () => {
                     size="lg" 
                     className="w-full font-montserrat font-semibold"
                   >
-                    Start Project
+                    Iniciar Projeto
                   </Button>
                 </form>
 
                 <p className="text-sm text-center text-muted-foreground mt-4 font-montserrat">
-                  We usually respond within 24 hours
+                  Normalmente respondemos em até 24 horas
                 </p>
               </CardContent>
             </Card>
@@ -144,7 +144,7 @@ const Contact = () => {
                 <CardContent className="p-6">
                   <div className="flex items-center space-x-3 mb-4">
                     <Mail className="text-neon-pink" size={24} />
-                    <h3 className="font-bold font-montserrat">Email Us</h3>
+                    <h3 className="font-bold font-montserrat">Envie-nos um E-mail</h3>
                   </div>
                   <p className="text-muted-foreground font-montserrat">
                     hello@3dimensionlabs.com
@@ -156,13 +156,13 @@ const Contact = () => {
                 <CardContent className="p-6">
                   <div className="flex items-center space-x-3 mb-4">
                     <Instagram className="text-neon-cyan" size={24} />
-                    <h3 className="font-bold font-montserrat">Follow Us</h3>
+                    <h3 className="font-bold font-montserrat">Siga-nos</h3>
                   </div>
                   <p className="text-muted-foreground font-montserrat mb-2">
                     @3dimensionlabs
                   </p>
                   <p className="text-sm text-muted-foreground font-montserrat">
-                    See our latest projects and behind-the-scenes content
+                    Veja nossos últimos projetos e bastidores
                   </p>
                 </CardContent>
               </Card>

--- a/src/components/CreativeDimensions.tsx
+++ b/src/components/CreativeDimensions.tsx
@@ -5,42 +5,42 @@ const CreativeDimensions = () => {
   const dimensions = [
     {
       name: "Eco Dimension",
-      description: "Sustainable 3D printing solutions",
+      description: "Soluções de impressão 3D sustentáveis",
       icon: Leaf,
       color: "bg-gradient-eco",
       textColor: "text-green-700",
     },
     {
       name: "Tech Dimension", 
-      description: "Cutting-edge prototypes & gadgets",
+      description: "Protótipos e gadgets de ponta",
       icon: Cpu,
       color: "bg-gradient-tech",
       textColor: "text-blue-violet",
     },
     {
       name: "Architecture",
-      description: "Precision architectural models",
+      description: "Modelos arquitetônicos de precisão",
       icon: Building,
       color: "bg-muted",
       textColor: "text-foreground",
     },
     {
       name: "Reef Aquarium",
-      description: "Marine habitat innovations",
+      description: "Inovações para habitats marinhos",
       icon: Waves,
       color: "bg-neon-cyan",
       textColor: "text-white",
     },
     {
       name: "Luix Shrimps",
-      description: "Ornamental aquatic solutions",
+      description: "Soluções aquáticas ornamentais",
       icon: Fish,
       color: "bg-blue-violet",
       textColor: "text-white",
     },
     {
       name: "Creativity",
-      description: "Limitless artistic expression",
+      description: "Expressão artística sem limites",
       icon: Palette,
       color: "bg-gradient-cube",
       textColor: "text-white",
@@ -52,10 +52,10 @@ const CreativeDimensions = () => {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold font-montserrat mb-6">
-            Creative <span className="text-neon-pink">Dimensions</span>
+            Dimensões <span className="text-neon-pink">Criativas</span>
           </h2>
           <p className="text-xl text-muted-foreground font-montserrat max-w-3xl mx-auto">
-            Explore our diverse portfolio across multiple dimensions of creativity and innovation
+            Explore nosso portfólio diversificado em múltiplas dimensões de criatividade e inovação
           </p>
         </div>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,10 +2,10 @@ import { Instagram, MessageSquare, Mail } from "lucide-react";
 
 const Footer = () => {
   const quickLinks = [
-    { name: "Home", href: "/#home" },
-    { name: "Portfolio", href: "/portfolio" },
-    { name: "Creative Dimensions", href: "/#dimensions" },
-    { name: "Contact", href: "/#contact" },
+    { name: "Início", href: "/#home" },
+    { name: "Portfólio", href: "/portfolio" },
+    { name: "Dimensões Criativas", href: "/#dimensions" },
+    { name: "Contato", href: "/#contact" },
   ];
 
   return (
@@ -20,17 +20,17 @@ const Footer = () => {
               <span className="text-blue-violet">Labs</span>
             </div>
             <p className="text-xl font-bold font-montserrat text-foreground italic mb-6">
-              "The dimension with no limits to creativity."
+              "A dimensão sem limites para a criatividade."
             </p>
             <p className="text-muted-foreground font-montserrat max-w-md">
-              We transform ideas into reality through precision 3D printing, innovative design, 
-              and limitless creativity. Quality under control, innovation without boundaries.
+              Transformamos ideias em realidade por meio de impressão 3D de precisão, design inovador
+              e criatividade sem limites. Qualidade sob controle, inovação sem fronteiras.
             </p>
           </div>
 
           {/* Quick Links */}
           <div>
-            <h3 className="font-bold font-montserrat text-foreground mb-4">Quick Links</h3>
+            <h3 className="font-bold font-montserrat text-foreground mb-4">Links Rápidos</h3>
             <ul className="space-y-2">
               {quickLinks.map((link) => (
                 <li key={link.name}>
@@ -47,7 +47,7 @@ const Footer = () => {
 
           {/* Social Media */}
           <div>
-            <h3 className="font-bold font-montserrat text-foreground mb-4">Connect</h3>
+            <h3 className="font-bold font-montserrat text-foreground mb-4">Conecte-se</h3>
             <div className="space-y-3">
               <div className="flex items-center space-x-3">
                 <Instagram className="text-neon-pink" size={20} />
@@ -69,14 +69,14 @@ const Footer = () => {
         <div className="border-t border-border mt-12 pt-8">
           <div className="flex flex-col md:flex-row justify-between items-center">
             <p className="text-muted-foreground font-montserrat text-sm">
-              © 2024 3DimensionLabs. All rights reserved.
+              © 2025 Lapix Lazuli inc
             </p>
             <div className="flex space-x-6 mt-4 md:mt-0">
               <a href="#" className="text-muted-foreground hover:text-neon-pink transition-colors font-montserrat text-sm">
-                Privacy Policy
+                Política de Privacidade
               </a>
               <a href="#" className="text-muted-foreground hover:text-neon-cyan transition-colors font-montserrat text-sm">
-                Terms of Service
+                Termos de Serviço
               </a>
             </div>
           </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,10 +6,10 @@ const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const navigation = [
-    { name: "Home", href: "/#home" },
-    { name: "Portfolio", href: "/portfolio" },
-    { name: "Creative Dimensions", href: "/#dimensions" },
-    { name: "Contact", href: "/#contact" },
+    { name: "Início", href: "/#home" },
+    { name: "Portfólio", href: "/portfolio" },
+    { name: "Dimensões Criativas", href: "/#dimensions" },
+    { name: "Contato", href: "/#contact" },
   ];
 
   return (

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -37,7 +37,7 @@ const Hero = () => {
           
           {/* Tagline */}
           <p className="text-lg md:text-xl font-montserrat mb-12 text-foreground">
-            On-demand printing. Quality under control.
+            Impressão sob demanda. Qualidade sob controle.
           </p>
 
           {/* Call-to-Action Buttons */}
@@ -48,7 +48,7 @@ const Hero = () => {
               className="px-8 py-4 text-lg font-semibold min-w-[200px]"
               onClick={() => navigate('/portfolio')}
             >
-              View Portfolio
+              Ver Portfólio
             </Button>
             
             <Button 
@@ -56,7 +56,7 @@ const Hero = () => {
               size="lg" 
               className="px-8 py-4 text-lg font-semibold min-w-[200px]"
             >
-              Buy Product
+              Comprar Produto
             </Button>
             
             <Button 
@@ -65,7 +65,7 @@ const Hero = () => {
               className="px-8 py-4 text-lg font-semibold min-w-[200px]"
               onClick={() => document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' })}
             >
-              Create Product
+              Criar Produto
             </Button>
           </div>
         </div>

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -6,13 +6,13 @@ import portfolioEco from "@/assets/portfolio-eco.jpg";
 import portfolioTech from "@/assets/portfolio-tech.jpg";
 
 const Portfolio = () => {
-  const [activeFilter, setActiveFilter] = useState("All");
+  const [activeFilter, setActiveFilter] = useState("Todos");
 
   const portfolioItems = [
     {
       id: 1,
       title: "Modern Office Complex",
-      category: "Architecture",
+      category: "Arquitetura",
       image: portfolioArch,
       description: "Precision architectural model showcasing modern design",
     },
@@ -26,14 +26,14 @@ const Portfolio = () => {
     {
       id: 3,
       title: "IoT Prototype Case",
-      category: "Tech",
+      category: "Tecnologia",
       image: portfolioTech,
       description: "Custom housing for electronic prototypes",
     },
     {
       id: 4,
       title: "Residential Tower",
-      category: "Architecture",
+      category: "Arquitetura",
       image: portfolioArch,
       description: "Detailed scale model of residential complex",
     },
@@ -47,15 +47,15 @@ const Portfolio = () => {
     {
       id: 6,
       title: "Sensor Housing",
-      category: "Tech",
+      category: "Tecnologia",
       image: portfolioTech,
       description: "Weatherproof housing for environmental sensors",
     },
   ];
 
-  const filters = ["All", "Architecture", "Eco", "Tech", "Reef", "Creativity"];
+  const filters = ["Todos", "Arquitetura", "Eco", "Tecnologia", "Recife", "Criatividade"];
 
-  const filteredItems = activeFilter === "All" 
+  const filteredItems = activeFilter === "Todos"
     ? portfolioItems 
     : portfolioItems.filter(item => item.category === activeFilter);
 
@@ -64,10 +64,10 @@ const Portfolio = () => {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold font-montserrat mb-6">
-            Our <span className="text-neon-cyan">Portfolio</span>
+            Nosso <span className="text-neon-cyan">Portfólio</span>
           </h2>
           <p className="text-xl text-muted-foreground font-montserrat max-w-3xl mx-auto mb-8">
-            Discover the precision and innovation behind every project we create
+            Descubra a precisão e inovação por trás de cada projeto que criamos
           </p>
 
           {/* Filter Buttons */}
@@ -118,7 +118,7 @@ const Portfolio = () => {
                       {item.category}
                     </span>
                     <Button variant="ghost" size="sm" className="text-neon-cyan hover:text-neon-pink">
-                      View Details
+                      Ver Detalhes
                     </Button>
                   </div>
                 </div>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -15,9 +15,9 @@ const NotFound = () => {
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+        <p className="text-xl text-gray-600 mb-4">Ops! Página não encontrada</p>
         <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
+          Voltar para o início
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- switch site language to Portuguese
- localize header, footer, hero and portfolio text
- translate contact page and 404 page
- update copyright year

## Testing
- `npm run lint` *(fails: react-refresh only-export-components, @typescript-eslint/no-empty-object-type)*

------
https://chatgpt.com/codex/tasks/task_e_6873c67b8384832ea4f3d7a4c2fc7b98