### PR TITLE
Add black outline and enlarge hero heading

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -25,7 +25,7 @@ const Hero = () => {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
         <div className="max-w-4xl mx-auto animate-fade-in-up">
           {/* Main Headline */}
-          <h1 className="text-5xl md:text-7xl font-bold font-montserrat mb-6 leading-tight">
+          <h1 className="text-6xl md:text-8xl font-bold font-montserrat mb-6 leading-tight text-outline-black">
             Transformamos <span className="text-neon-pink">ideias</span> em{" "}
             <span className="text-neon-cyan">realidade</span>
           </h1>

--- a/src/index.css
+++ b/src/index.css
@@ -209,3 +209,13 @@
 .animate-fade-in-up {
   animation: fadeInUp 0.6s ease-out;
 }
+
+@layer utilities {
+  .text-outline-black {
+    text-shadow:
+      -1px -1px 0 #000,
+      1px -1px 0 #000,
+      -1px 1px 0 #000,
+      1px 1px 0 #000;
+  }
+}


### PR DESCRIPTION
## Summary
- enlarge hero title font size and add new outline class
- add `.text-outline-black` utility for black text outline

## Testing
- `npm run lint` *(fails: react-refresh & no-empty-object-type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873c7393258832ea209128dfdb90b81