### PR TITLE
Add logo to navbar and set favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>3DimensionLabs - A dimensão sem limites para a criatividade</title>
+    <link rel="icon" type="image/png" href="/src/assets/geral/logo.png" />
     <meta name="description" content="Transforme ideias em realidade com impressão 3D de precisão. Impressão sob demanda, qualidade sob controle e inovação sem fronteiras." />
     <meta name="author" content="3DimensionLabs" />
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import logo from "@/assets/geral/logo.png";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -18,6 +19,7 @@ const Header = () => {
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <a href="/#home" className="flex items-center">
+            <img src={logo} alt="3DimensionLabs logo" className="h-8 w-8 mr-2" />
             <div className="text-2xl font-bold font-montserrat text-foreground">
               <span className="text-neon-pink">3D</span>
               <span className="text-neon-cyan">imension</span>


### PR DESCRIPTION
## Summary
- show logo in header navigation
- link new logo as site favicon

## Testing
- `npm run lint` *(fails: react-refresh and TypeScript ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873cd428668832e8dc0c7d1e664130a