### PR TITLE
Adjust hero background zoom and opacity

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,8 +7,8 @@ const Hero = () => {
   return (
     <section id="home" className="min-h-screen flex items-center justify-center relative overflow-hidden">
       {/* Background Image */}
-      <div 
-        className="absolute inset-0 bg-cover bg-center bg-no-repeat opacity-20"
+      <div
+        className="absolute inset-0 bg-contain bg-center bg-no-repeat opacity-40"
         style={{
           backgroundImage: `url(${heroImage})`,
         }}


### PR DESCRIPTION
## Summary
- tweak hero background to use `bg-contain` and higher opacity

## Testing
- `npm run lint` *(fails: no-empty-object-type in ui components)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687421b43158832eab39560f0f22061b